### PR TITLE
tar_outputs() now removes old output

### DIFF
--- a/test_pipeline.py
+++ b/test_pipeline.py
@@ -151,8 +151,9 @@ def tar_outputs(scan_date, dictionary):
 
     for k, v in dictionary['paths']['pipeline_outpath'].items():
 
-        if not os.path.isdir(os.path.join(cwd, scan_date, outdir)):
-            os.makedirs(os.path.join(cwd, scan_date, outdir))
+        if os.path.isdir(os.path.join(cwd, scan_date, outdir)):
+            shutil.rmtree(os.path.join(cwd, scan_date, outdir))
+        os.makedirs(os.path.join(cwd, scan_date, outdir))
 
         file_path = os.path.join(cwd, scan_date, outdir, f'{scan_date}_{v}_plants.tar') 
         print(f'Creating {file_path}.')


### PR DESCRIPTION
As requested by issue #12 